### PR TITLE
skip display if title matches

### DIFF
--- a/javascripts/discourse/helpers/render-watermark.js.es6
+++ b/javascripts/discourse/helpers/render-watermark.js.es6
@@ -15,11 +15,14 @@ const renderWatermarkDataURL = (canvas, settings, data) => {
     display_timestamp_font,
     display_timestamp_x,
     display_timestamp_y,
+    omit_if_title_matches,
   } = settings;
+
   const renderText = display_text.trim() !== "";
   const { username, timestamp } = data;
+  const noRender = Discourse.SiteSettings.title.match(omit_if_title_matches);
 
-  if (!(renderText || username || timestamp)) return;
+  if (noRender || !(renderText || username || timestamp)) return;
 
   canvas.width = width;
   canvas.height = height;

--- a/javascripts/discourse/helpers/render-watermark.js.es6
+++ b/javascripts/discourse/helpers/render-watermark.js.es6
@@ -15,14 +15,14 @@ const renderWatermarkDataURL = (canvas, settings, data) => {
     display_timestamp_font,
     display_timestamp_x,
     display_timestamp_y,
-    omit_if_title_matches,
+    include_if_title_matches,
   } = settings;
 
   const renderText = display_text.trim() !== "";
   const { username, timestamp } = data;
-  const noRender = Discourse.SiteSettings.title.match(omit_if_title_matches);
+  const okToRender = Discourse.SiteSettings.title.match(include_if_title_matches)
 
-  if (noRender || !(renderText || username || timestamp)) return;
+  if (!okToRender || !(renderText || username || timestamp)) return;
 
   canvas.width = width;
   canvas.height = height;

--- a/javascripts/discourse/helpers/render-watermark.js.es6
+++ b/javascripts/discourse/helpers/render-watermark.js.es6
@@ -1,3 +1,5 @@
+import { helperContext } from "discourse-common/lib/helpers";
+
 const renderWatermarkDataURL = (canvas, settings, data) => {
   const {
     tile_width: width,
@@ -20,7 +22,7 @@ const renderWatermarkDataURL = (canvas, settings, data) => {
 
   const renderText = display_text.trim() !== "";
   const { username, timestamp } = data;
-  const okToRender = Discourse.SiteSettings.title.match(include_if_title_matches)
+  const okToRender = helperContext().siteSettings.title.match(include_if_title_matches)
 
   if (!okToRender || !(renderText || username || timestamp)) return;
 

--- a/javascripts/discourse/helpers/render-watermark.js.es6
+++ b/javascripts/discourse/helpers/render-watermark.js.es6
@@ -22,7 +22,9 @@ const renderWatermarkDataURL = (canvas, settings, data) => {
 
   const renderText = display_text.trim() !== "";
   const { username, timestamp } = data;
-  const okToRender = helperContext().siteSettings.title.match(include_if_title_matches)
+  const container = Discourse.__container__;
+  const siteSettings = container.lookup("site-settings:main");
+  const okToRender = siteSettings.title.match(include_if_title_matches)
 
   if (!okToRender || !(renderText || username || timestamp)) return;
 

--- a/settings.yml
+++ b/settings.yml
@@ -145,9 +145,9 @@ display_timestamp_y:
     en: "The y-axis coordinate of the point at which to begin drawing the timestamp in the tile canvas, in pixels."
     pt_BR: "A coordenada no eixo y para o ponto em que a data/horário deve ser desenhada no canvas do bloco, em pixels."
 
-omit_if_title_matches:
-  default: "My Production site"
+include_if_title_matches:
+  default: ""
   type: string
   description:
-    en: "Do not display watermark if site title matches this string"
-    pt_BR: "Não exibir marca d'água se o título do site corresponder a essa string"
+    en: "Display watermark only if site title matches this string (empty string always matches)."
+    pt_BR: "Exibir marca d'água somente se o título do site corresponder a essa string (a string vazia sempre corresponde)."

--- a/settings.yml
+++ b/settings.yml
@@ -144,3 +144,9 @@ display_timestamp_y:
   description: 
     en: "The y-axis coordinate of the point at which to begin drawing the timestamp in the tile canvas, in pixels."
     pt_BR: "A coordenada no eixo y para o ponto em que a data/horário deve ser desenhada no canvas do bloco, em pixels."
+
+omit_if_title_matches:
+  default: "My Production site"
+  type: string
+  description:
+    en: "Do not display watermark if site title matches this"

--- a/settings.yml
+++ b/settings.yml
@@ -149,4 +149,5 @@ omit_if_title_matches:
   default: "My Production site"
   type: string
   description:
-    en: "Do not display watermark if site title matches this"
+    en: "Do not display watermark if site title matches this string"
+    pt_BR: "Não exibir marca d'água se o título do site corresponder a essa string"


### PR DESCRIPTION
Add a setting to disable the watermark if the site title matches a string.

Use case is to have the watermark show only on staging and development sites (which have a different title set in an ENV variable). This allows restoring the production database to the staging site (which would wipe out theme settings) and having the watermark display on the staging site, and do nothing on the production site.

I'll push another commit which has what appears to be a very bad Google translate for the Portugese. 