### PR TITLE
FIX: scrollEnabled setting not taking effect

### DIFF
--- a/javascripts/discourse/components/watermark-background.gjs
+++ b/javascripts/discourse/components/watermark-background.gjs
@@ -35,6 +35,7 @@ export default class WatermarkBackground extends Component {
     .split("|")
     .filter((id) => id !== "")
     .map((v) => new RegExp(v));
+  scrollEnabled = !!settings.scroll_enabled;
 
   #domElement;
 
@@ -259,7 +260,7 @@ export default class WatermarkBackground extends Component {
   <template>
     <div
       id="watermark-background"
-      class={{if @scrollEnabled "scroll" "fixed"}}
+      class={{if this.scrollEnabled "scroll" "fixed"}}
       {{didInsert this.setDomElement}}
     />
   </template>


### PR DESCRIPTION
Current 'scroll enabled' setting does not take effect, the watermark does not scroll with the page regardless of whether the setting is enabled. The component cannot directly read `@scrollEnabled` because no parameters are passed in the initializer.